### PR TITLE
Make test not fail on valid size

### DIFF
--- a/content.js
+++ b/content.js
@@ -60,7 +60,7 @@
       images.forEach((image, index) => {
         const node = new Image();
         node.addEventListener('load', () => {
-          if (node.width >= 1600) {
+          if (node.width > 1600) {
             pass = false;
             const pathname = new URL(node.src).pathname;
             const filename = pathname.substring(pathname.lastIndexOf('/') + 1);


### PR DESCRIPTION
The handbook says that images [1600px at a maximum](https://web.dev/handbook/markup-media/#body). Currently, the tool fails on exactly 1600px.